### PR TITLE
feat: add ceresdb engine proto

### DIFF
--- a/golang/gen-go.sh
+++ b/golang/gen-go.sh
@@ -4,7 +4,7 @@ set -ex
 
 GO_PREFIX_PATH=github.com/CeresDB/ceresdbproto/golang
 
-protoc --proto_path=../protos --go_out=. --go-grpc_out=. ../protos/*
+protoc --proto_path=../protos --go_out=. --go-grpc_out=. ../protos/cluster.proto ../protos/common.proto ../protos/meta_event.proto ../protos/meta_service.proto ../protos/meta_storage.proto ../protos/prometheus.proto ../protos/storage.proto
 
 rm -rf pkg && mv $GO_PREFIX_PATH/pkg .
 rm -rf github.com

--- a/protos/engine/manifest.proto
+++ b/protos/engine/manifest.proto
@@ -1,0 +1,171 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Manifest of engine
+syntax = "proto3";
+package manifest;
+
+import "cluster.proto";
+import "engine/schema.proto";
+import "engine/time_range.proto";
+
+// Meta update for a new space
+message AddSpaceMeta {
+  uint32 space_id = 1;
+  string space_name = 2;
+}
+
+// Meta update for a new table
+message AddTableMeta {
+  uint32 space_id = 1;
+  uint64 table_id = 2;
+  string table_name = 3;
+  // Schema of the table
+  schema.TableSchema schema = 4;
+  // Options of the table
+  TableOptions options = 5;
+  cluster.PartitionInfo partition_info = 6;
+}
+
+// Meta update for dropping a table
+message DropTableMeta {
+  uint32 space_id = 1;
+  uint64 table_id = 2;
+  string table_name = 3;
+}
+
+// Meta data of a sst file
+message AddFileMeta {
+  // Level of the file
+  uint32 level = 1;
+  // Id of the file
+  uint64 file_id = 2;
+  uint64 max_seq = 3;
+  time_range.TimeRange time_range = 4;
+  uint64 size = 5;
+  uint64 row_num = 6;
+  StorageFormat storage_format = 7;
+}
+
+// Meta data of the file to delete
+message DeleteFileMeta {
+  // Level of the file
+  uint32 level = 1;
+  // Id of the file
+  uint64 file_id = 2;
+}
+
+// Meta data of version edit to table
+message VersionEditMeta {
+  uint32 space_id = 1;
+  uint64 table_id = 2;
+  uint64 flushed_sequence = 3;
+  repeated AddFileMeta files_to_add = 4;
+  repeated DeleteFileMeta files_to_delete = 5;
+}
+
+// Meta data of schema update.
+message AlterSchemaMeta {
+  uint32 space_id = 1;
+  uint64 table_id = 2;
+  // New schema of the table.
+  schema.TableSchema schema = 3;
+  // Previous schema version.
+  uint32 pre_schema_version = 4;
+}
+
+// Meta data of schema update.
+message AlterOptionsMeta {
+  uint32 space_id = 1;
+  uint64 table_id = 2;
+  // New options of the table.
+  TableOptions options = 3;
+}
+
+// Meta update data to persist
+message MetaUpdate {
+  oneof meta {
+    AddTableMeta add_table = 1;
+    VersionEditMeta version_edit = 2;
+    AlterSchemaMeta alter_schema = 3;
+    AlterOptionsMeta alter_options = 4;
+    DropTableMeta drop_table = 5;
+  }
+}
+
+message Snapshot {
+  uint64 end_seq = 1;
+  AddTableMeta meta = 2;
+  VersionEditMeta version_edit = 3;
+}
+
+// Options of a table that need to persist
+message TableOptions {
+  // Segment duration in ms.
+  uint64 segment_duration = 1;
+  bool enable_ttl = 2;
+  uint64 ttl = 3;
+  uint32 arena_block_size = 4;
+  uint64 num_rows_per_row_group = 5;
+  CompactionStrategy compaction_strategy = 6;
+  CompactionOptions compaction_options = 7;
+  UpdateMode update_mode = 8;
+  uint32 write_buffer_size = 9;
+  Compression compression = 10;
+  // If sampling_segment_duration is true, then the segment duration
+  // is still unknown.
+  bool sampling_segment_duration = 11;
+  StorageFormatHint storage_format_hint = 12;
+}
+
+enum UpdateMode {
+  Overwrite = 0;
+  Append = 1;
+}
+
+message StorageFormatHint {
+  oneof hint {
+    // Auto means the storage format is automatically determined by CeresDB and
+    // its value have no specific meaning.
+    int32 auto = 1;
+    StorageFormat specific = 2;
+  }
+}
+
+enum StorageFormat {
+  Columnar = 0;
+  Hybrid = 1;
+}
+
+message CompactionOptions {
+  // Options for STCS
+  float bucket_low = 1;
+  float bucket_high = 2;
+  uint32 min_sstable_size = 3;
+  uint32 min_threshold = 4;
+  uint32 max_threshold = 5;
+  // Options for TWCS
+  TimeUnit timestamp_resolution = 6;
+}
+
+enum TimeUnit {
+  NANOSECONDS = 0;
+  MICROSECONDS = 1;
+  MILLISECONDS = 2;
+  SECONDS = 3;
+  MINUTES = 4;
+  HOURS = 5;
+  DAYS = 6;
+}
+
+enum CompactionStrategy {
+  DEFAULT = 0;
+  SIZE_TIERED = 1;
+  TIME_WINDOW = 2;
+}
+
+enum Compression {
+  UNCOMPRESSED = 0;
+  LZ4 = 1;
+  SNAPPY = 2;
+  ZSTD = 3;
+}

--- a/protos/engine/oss_cache.proto
+++ b/protos/engine/oss_cache.proto
@@ -1,0 +1,11 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package oss_cache;
+
+message Bytes {
+  // Cache value
+  bytes value = 1;
+  // CRC of value bytes
+  uint32 crc = 2;
+}

--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -1,0 +1,76 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package remote_engine;
+
+import "engine/schema.proto";
+import "engine/time_range.proto";
+import "common.proto";
+
+service RemoteEngineService {
+  rpc Read(ReadRequest) returns (stream ReadResponse) {}
+  rpc Write(WriteRequest) returns (WriteResponse) {}
+}
+
+message TableIdentifier {
+  string catalog = 1;
+  string schema = 2;
+  string table = 3;
+}
+
+message ReadOptions {
+  uint64 batch_size = 1;
+  uint64 read_parallelism = 2;
+  // -1 means no timeout
+  int64 timeout_ms = 3;
+}
+
+message Predicate {
+  repeated bytes exprs = 1;
+  time_range.TimeRange time_range = 2;
+}
+
+enum ReadOrder {
+  None = 0;
+  Asc = 1;
+  Desc = 2;
+}
+
+message TableReadRequest {
+  uint64 request_id = 1;
+  ReadOptions opts = 2;
+  schema.ProjectedSchema projected_schema = 3;
+  Predicate predicate = 4;
+  ReadOrder order = 5;
+}
+
+message ReadRequest {
+  TableIdentifier table = 1;
+  TableReadRequest read_request = 2;
+}
+
+message ReadResponse {
+  common.ResponseHeader header = 1;
+  // Version of row encoding method
+  uint32 version = 2;
+  bytes rows = 3;
+}
+
+message RowGroup {
+  // Version of row encoding method
+  schema.TableSchema table_schema = 1;
+  int64 min_timestamp = 2;
+  int64 max_timestamp = 3;
+  uint32 version = 4;
+  repeated bytes rows = 5;
+}
+
+message WriteRequest {
+  TableIdentifier table = 1;
+  RowGroup row_group = 2;
+}
+
+message WriteResponse {
+  common.ResponseHeader header = 1;
+  uint64 affected_rows = 2;
+}

--- a/protos/engine/schema.proto
+++ b/protos/engine/schema.proto
@@ -1,0 +1,64 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package schema;
+
+// Table Schema
+message TableSchema {
+    // Schema of each column
+    repeated ColumnSchema columns = 1;
+    // Version of the schema
+    uint32 version = 2;
+    // Timestamp index in columns
+    uint32 timestamp_index = 3;
+    // Primary key index
+    repeated uint64 primary_key_indexes = 4;
+}
+
+// Column schema
+message ColumnSchema {
+  // Column name
+  string name = 1;
+  // Column type
+  DataType data_type = 2;
+  // Is the column nullable
+  bool is_nullable = 3;
+  // Id of the column
+  uint32 id = 4;
+  // Is the column used as tag
+  bool is_tag = 5;
+  // Comment of the column
+  string comment = 6;
+  // Default value expr of the column
+  bytes default_value = 7;
+}
+
+// Data type of column
+// TODO(yingwen): Do we need a null type?
+enum DataType {
+  NULL = 0;
+  TIMESTAMP = 1;
+  DOUBLE = 2;
+  VARBINARY = 3;
+  STRING = 4;
+  UINT64 = 5;
+  FLOAT = 6;
+  INT64 = 7;
+  INT32 = 8;
+  INT16 = 9;
+  INT8 = 10;
+  UINT32 = 11;
+  UINT16 = 12;
+  UINT8 = 13;
+  BOOL = 14;
+}
+
+// Projected Schema
+message ProjectedSchema {
+  TableSchema table_schema = 1;
+  Projection projection = 2;
+}
+
+message Projection {
+  repeated uint64 idx = 1;
+}

--- a/protos/engine/sst.proto
+++ b/protos/engine/sst.proto
@@ -1,0 +1,38 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Sst types
+syntax = "proto3";
+package sst;
+
+import "engine/schema.proto";
+import "engine/time_range.proto";
+
+message SstMetaData {
+  oneof MetaData {
+    ParquetMetaData parquet = 1;
+  }
+}
+
+message ParquetFilter {
+  message RowGroupFilter {
+    repeated bytes column_filters = 1;
+  };
+
+  uint32 version = 1;
+  repeated RowGroupFilter row_group_filters = 2;
+}
+
+/// Used by ssts encoded by parquet, incuding columar&hybrid storage formats.
+message ParquetMetaData {
+  // Min key in the sst
+  bytes min_key = 1;
+  // Max key in the sst
+  bytes max_key = 2;
+  // Max sequence number in the sst
+  uint64 max_sequence = 3;
+  // The time range of the sst
+  time_range.TimeRange time_range = 4;
+  schema.TableSchema schema = 5;
+  ParquetFilter filter = 6;
+  repeated uint32 collapsible_cols_idx = 7;
+}

--- a/protos/engine/sys_catalog.proto
+++ b/protos/engine/sys_catalog.proto
@@ -1,0 +1,54 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Types for sys catalog
+syntax = "proto3";
+package sys_catalog;
+
+// Catalog entry
+message CatalogEntry {
+  // Name of catalog
+  string catalog_name = 1;
+  // Created time: ms
+  int64 created_time = 2;
+}
+
+// Schema entry
+message SchemaEntry {
+  // Name of catalog
+  string catalog_name = 1;
+  // Name of schema
+  string schema_name = 2;
+  // Id of the schema
+  uint32 schema_id = 3;
+  // Created time: ms
+  int64 created_time = 4;
+}
+
+// State of the table
+enum TableState {
+  STABLE = 0;
+  DROPPING = 1;
+  DROPPED = 2;
+}
+
+// Table entry
+message TableEntry {
+  // Name of catalog
+  string catalog_name = 1;
+  // Name of schema
+  string schema_name = 2;
+  // Schema id
+  uint32 schema_id = 3;
+  // Table id
+  uint64 table_id = 4;
+  // Table name
+  string table_name = 5;
+  // Table engine type
+  string engine = 6;
+  // The state of the table.
+  TableState state = 7;
+  // Created time: ms
+  int64 created_time = 8;
+  // Modified time: ms
+  int64 modified_time = 9;
+}

--- a/protos/engine/table_requests.proto
+++ b/protos/engine/table_requests.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Types for table requests
+syntax = "proto3";
+package table_requests;
+
+import "engine/schema.proto";
+
+// Write table request
+message WriteRequest {
+  // Version of row encoding method
+  uint32 version = 1;
+  // Schema of rows
+  schema.TableSchema schema = 2;
+  // Rows in bytes
+  //
+  // Each row is encoded in the same format as memtable
+  repeated bytes rows = 3;
+}

--- a/protos/engine/time_range.proto
+++ b/protos/engine/time_range.proto
@@ -1,0 +1,12 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package time_range;
+
+// Time range of [start, end)
+message TimeRange {
+  // inclusive start
+  int64 start = 1;
+  // exclusive end
+  int64 end = 2;
+}

--- a/protos/engine/wal_on_mq.proto
+++ b/protos/engine/wal_on_mq.proto
@@ -1,0 +1,20 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package wal_on_mq;
+
+message TableMetaData {
+    uint64 table_id = 1;
+    uint64 next_sequence_num = 2;
+    uint64 latest_marked_deleted = 3;
+    int64 current_high_watermark = 4;
+    oneof safe_delete_offset {
+        int64 offset = 5;
+    }
+}
+
+// Meta value used in wal's message queue implementation.
+// The shard's all tables' meta data are stored in it.
+message RegionMetaSnapshot {
+    repeated TableMetaData entries = 2;
+}

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -14,6 +14,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "../protos/meta_storage.proto",
             "../protos/prometheus.proto",
             "../protos/storage.proto",
+            // engine
+            "../protos/engine/schema.proto",
+            "../protos/engine/manifest.proto",
+            "../protos/engine/oss_cache.proto",
+            "../protos/engine/remote_engine.proto",
+            "../protos/engine/sst.proto",
+            "../protos/engine/sys_catalog.proto",
+            "../protos/engine/table_requests.proto",
+            "../protos/engine/time_range.proto",
+            "../protos/engine/wal_on_mq.proto",
         ],
         &["../protos"],
     )?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,3 +9,14 @@ pub mod meta_service;
 pub mod meta_storage;
 pub mod prometheus;
 pub mod storage;
+
+// engine
+pub mod manifest;
+pub mod oss_cache;
+pub mod remote_engine;
+pub mod schema;
+pub mod sst;
+pub mod sys_catalog;
+pub mod table_requests;
+pub mod time_range;
+pub mod wal_on_mq;


### PR DESCRIPTION
Put the [`proto`](https://github.com/CeresDB/ceresdb/tree/main/proto) used by `ceresdb` in the `ceresdbproto` repo for management.