### PR TITLE
support disable vendored protoc

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "prost",
  "protoc-bin-vendored",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceresdbproto"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/CeresDB/ceresdbproto"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -70,10 +70,18 @@ impl Builder {
     }
 }
 
+const ENABLE_VENDOR_ENV: &str = "CERESDBPROTO_ENABLE_VENDORED";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Download the protoc and set the path for tonic_build.
-    let protoc_path = protoc_bin_vendored::protoc_bin_path().map_err(|e| Box::new(e))?;
-    std::env::set_var("PROTOC", protoc_path.as_os_str());
+
+    println!("cargo:rerun-if-env-changed={}", ENABLE_VENDOR_ENV);
+
+    let enable_vendor = std::env::var(ENABLE_VENDOR_ENV).unwrap_or("true".to_string());
+    if "true" == enable_vendor {
+        let protoc_path = protoc_bin_vendored::protoc_bin_path().map_err(|e| Box::new(e))?;
+        std::env::set_var("PROTOC", protoc_path.as_os_str());
+    }
 
     // Build protos.
     let out_dir = std::env::var("OUT_DIR").map_err(|e| Box::new(e))?;


### PR DESCRIPTION
Add `CERESDBPROTO_ENABLE_VENDORED` to control whether use vendored protoc, which defaults to true.

The reason I want to add this is because https://github.com/stepancheg/rust-protoc-bin-vendored/issues/1.
