### PR TITLE
feat: add disable_index_for_non_tag_column

### DIFF
--- a/protos/engine/manifest.proto
+++ b/protos/engine/manifest.proto
@@ -116,6 +116,7 @@ message TableOptions {
   // is still unknown.
   bool sampling_segment_duration = 11;
   StorageFormatHint storage_format_hint = 12;
+  bool disable_index_for_non_tag_column = 13;
 }
 
 enum UpdateMode {


### PR DESCRIPTION
Disable index for non tag column to reduce the CPU cost of build xor filter.